### PR TITLE
catboost 1.2.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   #  Yandex supplies whl files on PyPI for:
   # - Linux: Python 3.8, 3.9, 3.10, 3.11, 3.12
   # - OS X: Python 3.8, 3.9, 3.10, 3.11, 3.12


### PR DESCRIPTION
catboost 1.2.3 

**Destination channel:** Defaults

### Links

- [PKG-8224]
- dev_url:        https://github.com/catboost/catboost/tree/v1.2.3
- conda_forge:    https://github.com/conda-forge/catboost-feedstock
- pypi:           https://pypi.org/project/catboost/1.2.3
- pypi inspector: https://inspector.pypi.io/project/catboost/1.2.3

### Explanation of changes:

- new version number


[PKG-8224]: https://anaconda.atlassian.net/browse/PKG-8224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ