### PR TITLE
catboost 1.2.8 

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 YANDEX LLC
+Copyright 2017-2024 YANDEX LLC
 
                                Apache License
                            Version 2.0, January 2004

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,4 +18,8 @@ IF "%PY_VER%"=="3.12" (
 	%PYTHON% -m pip install --no-deps --no-build-isolation https://pypi.org/packages/cp312/c/catboost/catboost-%PKG_VERSION%-cp312-cp312-win_amd64.whl
 )
 
+IF "%PY_VER%"=="3.13" (
+	%PYTHON% -m pip install --no-deps --no-build-isolation https://pypi.org/packages/cp313/c/catboost/catboost-%PKG_VERSION%-cp313-cp313-win_amd64.whl
+)
+
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,6 +34,9 @@ if [ `uname` == Darwin ]; then
     elif [ "$PY_VER" == "3.12" ]; then
         WHL_FILE=catboost-${PKG_VERSION}-cp312-cp312-macosx_${SDK_VER}_universal2.whl
         curl -Lso "$WHL_FILE" https://pypi.org/packages/cp312/c/catboost/catboost-${PKG_VERSION}-cp312-cp312-macosx_11_0_universal2.whl
+    elif [ "$PY_VER" == "3.13" ]; then
+        WHL_FILE=catboost-${PKG_VERSION}-cp313-cp313-macosx_${SDK_VER}_universal2.whl
+        curl -Lso "$WHL_FILE" https://pypi.org/packages/cp313/c/catboost/catboost-${PKG_VERSION}-cp313-cp313-macosx_11_0_universal2.whl
     fi
 fi
 
@@ -56,6 +59,8 @@ if [ `uname` == Linux ]; then
         WHL_FILE=https://pypi.org/packages/cp311/c/catboost/catboost-${PKG_VERSION}-cp311-cp311-manylinux2014_${TARGET_ARCH}.whl
     elif [ "$PY_VER" == "3.12" ]; then
         WHL_FILE=https://pypi.org/packages/cp312/c/catboost/catboost-${PKG_VERSION}-cp312-cp312-manylinux2014_${TARGET_ARCH}.whl
+    elif [ "$PY_VER" == "3.13" ]; then
+        WHL_FILE=https://pypi.org/packages/cp313/c/catboost/catboost-${PKG_VERSION}-cp313-cp313-manylinux2014_${TARGET_ARCH}.whl
     fi
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - pip
     - setuptools >=64.0
     - wheel
-    - cython >=3.0.10,<3.1
   run:
     - python
     - numpy >=1.16.0,<3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cython >=3.0.10,<3.1
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.16.0,<3.0
     - pandas >=0.24.0
     - scipy
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,10 @@ build:
 
 requirements:
   build:
+    # needs to suppress Cython needs C compiler error.
+    - {{ compiler('c') }}
+    - cmake
+    - make  # [unix]
     # curl is needed only for downloading whl files in build.sh
     - curl 8.12.1
   host:
@@ -17,10 +21,7 @@ requirements:
     - pip
     - setuptools >=64.0
     - wheel
-    - cmake
-    - make  # [not win]
     - cython >=3.0.10,<3.1
-    - jupyterlab >=3.0.6,<3.6.0
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "catboost" %}
-{% set version = "1.2.3" %}
+{% set version = "1.2.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +7,23 @@ package:
 
 build:
   number: 0
-  #  Yandex supplies whl files on PyPI for:
-  # - Linux: Python 3.8, 3.9, 3.10, 3.11, 3.12
-  # - OS X: Python 3.8, 3.9, 3.10, 3.11, 3.12
-  # - Win-64: Python 3.8, 3.9, 3.10, 3.11, 3.12
-  # There are issues with python 3.8 on macOS 11.x: https://github.com/conda-forge/python-feedstock/issues/445
-  #  so Conda has issues with tags compatibility with platform tags 'macosx_11_0_...'
-  #  so disable this configuration for now
-  skip: True  # [(osx and x86_64) and py==38]
-  # TODO: support Linux on ppc64le: https://github.com/catboost/catboost/issues/2145 and s390x
-  skip: True  # [ppc64le or s390x]
-  missing_dso_whitelist:         # [linux]
-    - '**/libdl.so.2'            # [linux]
-    - '**/ld-linux-x86-64.so.2'  # [linux]
-    - '**/libc.so.6'             # [linux]
-    - '**/libm.so.6'             # [linux]
-    - '**/librt.so.1'            # [linux]
-    - '**/libpthread.so.0'       # [linux]
+
 requirements:
   build:
     # curl is needed only for downloading whl files in build.sh
-    - curl 7.88.1
+    - curl 8.12.1
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=64.0
     - wheel
+    - cmake
+    - make  # [not win]
+    - cython >=3.0.10,<3.1
+    - jupyterlab >=3.0.6,<3.6.0
   run:
     - python
-    - numpy >=1.16.0
+    - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
     - six
@@ -48,7 +36,11 @@ requirements:
     - ipywidgets >=7.0,<9.0
 
 test:
-  # imports and pip check are in run_test.py
+  imports:
+    - catboost
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
 
@@ -56,7 +48,8 @@ about:
   home: https://catboost.ai
   license: Apache-2.0
   license_family: Apache
-  license_file: LICENSE
+  license_file:
+    - LICENSE
   summary: Gradient boosting on decision trees library
   description: |
     General purpose gradient boosting on decision trees library with categorical features support out of the box.


### PR DESCRIPTION
catboost 1.2.8 

**Destination channel:** Defaults

### Links

- [PKG-7512]
- dev_url:        https://github.com/catboost/catboost/tree/v1.2.8
- conda_forge:    https://github.com/conda-forge/catboost-feedstock
- pypi:           https://pypi.org/project/catboost/1.2.8
- pypi inspector: https://inspector.pypi.io/project/catboost/1.2.8

### Explanation of changes:

- new version


[PKG-7512]: https://anaconda.atlassian.net/browse/PKG-7512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ